### PR TITLE
Use ":" instead of "-" as the first separator after the HRP

### DIFF
--- a/ref/c/tests.c
+++ b/ref/c/tests.c
@@ -20,7 +20,7 @@ static struct test_vector test_vectors[] = {
     {
         TXREF_MAGIC_BTC_MAINNET,
         TXREF_BECH32_HRP_MAINNET,
-        "tx1-rjk0-u5ng-4jsf-mc",
+        "tx1:rjk0-u5ng-4jsf-mc",
         466793,
         2205,
         0,0,0
@@ -28,7 +28,7 @@ static struct test_vector test_vectors[] = {
     {
         TXREF_MAGIC_BTC_MAINNET,
         TXREF_BECH32_HRP_MAINNET,
-        "tx1-rjk0-u5n1-2jsi-mc", /* error correct test >2tsi< instead of >4jsf<*/
+        "tx1:rjk0-u5n1-2jsi-mc", /* error correct test >2tsi< instead of >4jsf<*/
         466793,
         2205,
         1,0,0
@@ -36,7 +36,7 @@ static struct test_vector test_vectors[] = {
     {
         TXREF_MAGIC_BTC_MAINNET,
         TXREF_BECH32_HRP_MAINNET,
-        "tx1-rqqq-qqqq-qmhu-qk",
+        "tx1:rqqq-qqqq-qmhu-qk",
         0,
         0,
         0,0,0
@@ -44,7 +44,7 @@ static struct test_vector test_vectors[] = {
     {
         TXREF_MAGIC_BTC_MAINNET,
         TXREF_BECH32_HRP_MAINNET,
-        "tx1-rzqq-qqqq-uvlj-ez",
+        "tx1:rzqq-qqqq-uvlj-ez",
         1,
         0,
         0,0,0
@@ -52,7 +52,7 @@ static struct test_vector test_vectors[] = {
     {
         TXREF_MAGIC_BTC_MAINNET,
         TXREF_BECH32_HRP_MAINNET,
-        "tx1-rjk0-u5ng-4jsf-mc", /* complete invalid */
+        "tx1:rjk0-u5ng-4jsf-mc", /* complete invalid */
         0,
         0,
         1,1,0 /* enc & dec must fail */
@@ -60,7 +60,7 @@ static struct test_vector test_vectors[] = {
     {
         TXREF_MAGIC_BTC_MAINNET,
         TXREF_BECH32_HRP_MAINNET,
-        "tx1-r7ll-lrar-a27h-kt",
+        "tx1:r7ll-lrar-a27h-kt",
         2097151, /* last valid block height with current enc/dec version is 0x1FFFFF*/
         1000,
         0,0,0
@@ -76,7 +76,7 @@ static struct test_vector test_vectors[] = {
     {
         TXREF_MAGIC_BTC_MAINNET,
         TXREF_BECH32_HRP_MAINNET,
-        "tx1-r7ll-llll-khym-tq",
+        "tx1:r7ll-llll-khym-tq",
         2097151, /* last valid block height with current enc/dec version is 0x1FFFFF*/
         8191, /* last valid tx pos is 0x1FFF */
         0,0,0
@@ -92,7 +92,7 @@ static struct test_vector test_vectors[] = {
     {
         TXREF_MAGIC_BTC_MAINNET,
         TXREF_BECH32_HRP_MAINNET,
-        "tx1-r7ll-lrqq-vq5e-gg",
+        "tx1:r7ll-lrqq-vq5e-gg",
         2097151, /* last valid block height with current enc/dec version is 0x1FFFFF*/
         0,
         0,0,0
@@ -100,7 +100,7 @@ static struct test_vector test_vectors[] = {
     {
         TXREF_MAGIC_BTC_MAINNET,
         TXREF_BECH32_HRP_MAINNET,
-        "tx1-rqqq-qull-6v87-r7",
+        "tx1:rqqq-qull-6v87-r7",
         0,
         8191, /* last valid tx pos is 0x1FFF */
         0,0,0
@@ -108,7 +108,7 @@ static struct test_vector test_vectors[] = {
     {
         TXREF_MAGIC_BTC_MAINNET,
         TXREF_BECH32_HRP_MAINNET,
-        "tx1-rjk0-u5ng-gghq-fkg7", /* valid Bech32, but 10x5bit packages instead of 8 */
+        "tx1:rjk0-u5ng-gghq-fkg7", /* valid Bech32, but 10x5bit packages instead of 8 */
         0,
         0,
         3,2,0 /* ignore encoding */
@@ -116,7 +116,7 @@ static struct test_vector test_vectors[] = {
     {
         TXREF_MAGIC_BTC_MAINNET,
         TXREF_BECH32_HRP_MAINNET,
-        "tx1-rjk0-u5qd-s43z", /* valid Bech32, but 6x5bit packages instead of 8 */
+        "tx1:rjk0-u5qd-s43z", /* valid Bech32, but 6x5bit packages instead of 8 */
         0,
         0,
         3,2,0 /* ignore encoding */
@@ -124,7 +124,7 @@ static struct test_vector test_vectors[] = {
     {
         0xB,
         TXREF_BECH32_HRP_MAINNET,
-        "tx1-t7ll-llll-gey7-ez",
+        "tx1:t7ll-llll-gey7-ez",
         2097151,
         8191,
         0,0,0 /* ignore encoding */
@@ -132,7 +132,7 @@ static struct test_vector test_vectors[] = {
     {
         TXREF_MAGIC_BTC_MAINNET,
         TXREF_BECH32_HRP_MAINNET,
-        "tx1-rk63-uvxf-9pqc-sy",
+        "tx1:rk63-uvxf-9pqc-sy",
         467883,
         2355,
         0,0,0 /* ignore encoding */
@@ -140,7 +140,7 @@ static struct test_vector test_vectors[] = {
     {
         TXREF_MAGIC_BTC_TESTNET,
         TXREF_BECH32_HRP_TESTNET,
-        "txtest1-xk63-uqvx-fqx8-xqr8",
+        "txtest1:xk63-uqvx-fqx8-xqr8",
         467883,
         2355,
         0,0,1 /* ignore encoding */
@@ -148,7 +148,7 @@ static struct test_vector test_vectors[] = {
     {
         TXREF_MAGIC_BTC_TESTNET,
         TXREF_BECH32_HRP_TESTNET,
-        "txtest1-xqqq-qqqq-qqkn-3gh9",
+        "txtest1:xqqq-qqqq-qqkn-3gh9",
         0,
         0,
         0,0,1 /* ignore encoding */
@@ -156,7 +156,7 @@ static struct test_vector test_vectors[] = {
     {
         TXREF_MAGIC_BTC_TESTNET,
         TXREF_BECH32_HRP_TESTNET,
-        "txtest1-x7ll-llll-llj9-t9dk",
+        "txtest1:x7ll-llll-llj9-t9dk",
         0x3FFFFFF,
         0x3FFFF,
         0,0,1 /* ignore encoding */

--- a/ref/c/txref_code.c
+++ b/ref/c/txref_code.c
@@ -84,20 +84,20 @@ int btc_txref_encode(
     /* add the dashes */
     olen = strlen(output);
     if (non_standard == 0) {
-      memcpy(output+olen+2, output+olen-2, 2); //including 0 byte
+      memmove(output+olen+2, output+olen-2, 2); //including 0 byte
       output[olen+4] = 0;
-      memcpy(output+olen-3, output+olen-6, 4);
-      memcpy(output+olen-8, output+olen-10, 4);
-      memcpy(output+olen-13, output+olen-14, 4);
+      memmove(output+olen-3, output+olen-6, 4);
+      memmove(output+olen-8, output+olen-10, 4);
+      memmove(output+olen-13, output+olen-14, 4);
       output[1+hrplen] = ':'; output[6+hrplen] = '-'; output[11+hrplen] = '-'; output[16+hrplen] = '-';
     }
     else {
       // use 16 char encoding (test networks)
-      memcpy(output+olen, output+olen-4, 4); //including 0 byte
+      memmove(output+olen, output+olen-4, 4); //including 0 byte
       output[olen+4] = 0;
-      memcpy(output+olen-5, output+olen-8, 4);
-      memcpy(output+olen-10, output+olen-12, 4);
-      memcpy(output+olen-15, output+olen-16, 4);
+      memmove(output+olen-5, output+olen-8, 4);
+      memmove(output+olen-10, output+olen-12, 4);
+      memmove(output+olen-15, output+olen-16, 4);
       output[1+hrplen] = ':'; output[6+hrplen] = '-'; output[11+hrplen] = '-'; output[16+hrplen] = '-';
     }
     return res;

--- a/ref/c/txref_code.c
+++ b/ref/c/txref_code.c
@@ -89,7 +89,7 @@ int btc_txref_encode(
       memcpy(output+olen-3, output+olen-6, 4);
       memcpy(output+olen-8, output+olen-10, 4);
       memcpy(output+olen-13, output+olen-14, 4);
-      output[1+hrplen] = '-'; output[6+hrplen] = '-'; output[11+hrplen] = '-'; output[16+hrplen] = '-';
+      output[1+hrplen] = ':'; output[6+hrplen] = '-'; output[11+hrplen] = '-'; output[16+hrplen] = '-';
     }
     else {
       // use 16 char encoding (test networks)
@@ -98,7 +98,7 @@ int btc_txref_encode(
       memcpy(output+olen-5, output+olen-8, 4);
       memcpy(output+olen-10, output+olen-12, 4);
       memcpy(output+olen-15, output+olen-16, 4);
-      output[1+hrplen] = '-'; output[6+hrplen] = '-'; output[11+hrplen] = '-'; output[16+hrplen] = '-';
+      output[1+hrplen] = ':'; output[6+hrplen] = '-'; output[11+hrplen] = '-'; output[16+hrplen] = '-';
     }
     return res;
 }
@@ -115,7 +115,7 @@ int btc_txref_decode(
     uint8_t buf[strlen(txref_id)];
     int res;
 
-    /* max TXREF_LEN_WITHOUT_HRP (+4 dashes) chars are allowed for now */
+    /* max TXREF_LEN_WITHOUT_HRP (+4 separators) chars are allowed for now */
     if (strlen(txref_id) < TXREF_LEN_WITHOUT_HRP+4) {
         return -1;
     }
@@ -123,7 +123,7 @@ int btc_txref_decode(
     memset(txref_id_no_d, 0, sizeof(txref_id_no_d));
 
     for(i = 0; i < strlen(txref_id); i++) {
-        if (txref_id[i]!='-') {
+        if (txref_id[i]!='-' && txref_id[i]!=':') {
             txref_id_no_d[strlen(txref_id_no_d)] = txref_id[i];
         }
     }


### PR DESCRIPTION
Changes "hrp-" to "hrp:"

This is in line with https://github.com/bitcoin/bips/pull/555#issuecomment-315531400 and https://github.com/bitcoin/bips/pull/555#issuecomment-315517707